### PR TITLE
Feature/recruitment connections

### DIFF
--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -4,7 +4,7 @@ use base64::{decode_config, URL_SAFE};
 
 use self::resolvers::{
     prefecture_resolver::PrefectureQuery,
-    recruitment_resolver::RecruitmentMutation,
+    recruitment_resolver::{RecruitmentMutation, RecruitmentQuery},
     sport_resolver::SportQuery,
     tag_resolver::{TagMutation, TagQuery},
     user_resolver::{UserMutation, UserQuery},
@@ -16,9 +16,17 @@ pub mod mail;
 pub mod models;
 pub mod mutations;
 pub mod resolvers;
+pub mod utils;
 
 #[derive(MergedObject, Default)]
-pub struct Query(RootQuery, PrefectureQuery, SportQuery, TagQuery, UserQuery);
+pub struct Query(
+    RootQuery,
+    PrefectureQuery,
+    SportQuery,
+    TagQuery,
+    UserQuery,
+    RecruitmentQuery,
+);
 #[derive(MergedObject, Default)]
 pub struct Mutation(UserMutation, RecruitmentMutation, TagMutation);
 

--- a/src/graphql/resolvers/recruitment_resolver.rs
+++ b/src/graphql/resolvers/recruitment_resolver.rs
@@ -6,19 +6,18 @@ use crate::{
     graphql::{
         auth::get_viewer,
         id_decode,
-        models::recruitment::{self, Recruitment},
+        models::recruitment::{self, get_recruitments, is_next_recruitment, Recruitment},
         mutations::recruitment_mutation::{
             CreateRecruitmentResult, CreateRecruitmentSuccess, RecruitmentInput,
             UpdateRecruitmentResult, UpdateRecruitmentSuccess,
         },
+        utils::pagination::{PageInfo, SearchParams},
     },
 };
 
-use super::PageInfo;
-
 #[derive(Debug)]
 pub struct RecruitmentConnection {
-    pub edges: Option<Vec<Recruitment>>,
+    pub edges: Option<Vec<RecruitmentEdge>>,
     pub page_info: PageInfo,
 }
 

--- a/src/graphql/resolvers/recruitment_resolver.rs
+++ b/src/graphql/resolvers/recruitment_resolver.rs
@@ -23,8 +23,8 @@ pub struct RecruitmentConnection {
 
 #[Object]
 impl RecruitmentConnection {
-    pub async fn edges(&self) -> Option<Vec<Recruitment>> {
-        self.edges.to_owned()
+    pub async fn edges(&self) -> Option<Vec<RecruitmentEdge>> {
+        self.edges.clone()
     }
     pub async fn page_info(&self) -> PageInfo {
         PageInfo {

--- a/src/graphql/resolvers/recruitment_resolver.rs
+++ b/src/graphql/resolvers/recruitment_resolver.rs
@@ -27,12 +27,7 @@ impl RecruitmentConnection {
         self.edges.clone()
     }
     pub async fn page_info(&self) -> PageInfo {
-        PageInfo {
-            start_cursor: None,
-            end_cursor: None,
-            has_next_page: true,
-            has_previous_page: true,
-        }
+        self.page_info.clone()
     }
 }
 


### PR DESCRIPTION
## やったこと
募集一覧を表示できるようにrecruitments_queryを実装
RecruitmentConnectionのedgesをOption<Vec<Recruitment>>になっていたのでOption<Vec<RecruitmentEdge>>に修正
RecruitmentConnectionのpage_infoはcloneで返す

## やらないこと
基本的なページネーションしか実装していない
カテゴリ、開始日時、フリーワードで検索できるようにする

## できるようになること（ユーザ目線）
募集の一覧が表示されるようになる

## できなくなること（ユーザ目線）
特になし

## 動作確認
募集の一覧を取得できることを確認
after: null, first: 10の場合は降順で10件取得する
after: "unique id", first: 10の場合はafterを基準に降順で10件取得する

## その他
特になし
