### PR TITLE
Feature/viewer recruitment connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,9 +80,12 @@ dependencies = [
  "chrono",
  "fast_chemail",
  "fnv",
+ "futures-channel",
+ "futures-timer",
  "futures-util",
  "http",
  "indexmap",
+ "lru",
  "mime",
  "multer",
  "num-traits",
@@ -367,6 +370,7 @@ dependencies = [
  "argon2",
  "async-graphql",
  "async-graphql-axum",
+ "async-trait",
  "axum",
  "base64",
  "chrono",
@@ -760,6 +764,12 @@ name = "futures-task"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
@@ -1180,6 +1190,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "lru"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
+dependencies = [
+ "hashbrown",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,9 +479,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f39818dcfc97d45b03953c1292efc4e80954e1583c4aa770bac1383e2310a4"
+checksum = "3f83d0ebf42c6eafb8d7c52f7e5f2d3003b89c7aa4fd2b79229209459a849af8"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -491,9 +491,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e580d70777c116df50c390d1211993f62d40302881e54d4b79727acb83d0199"
+checksum = "07d050484b55975889284352b0ffc2ecbda25c0c55978017c132b29ba0818a86"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -506,15 +506,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56a46460b88d1cec95112c8c363f0e2c39afdb237f60583b0b36343bf627ea9c"
+checksum = "99d2199b00553eda8012dfec8d3b1c75fce747cf27c169a270b3b99e3448ab78"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747b608fecf06b0d72d440f27acc99288207324b793be2c17991839f3d4995ea"
+checksum = "dcb67a6de1f602736dd7eaead0080cf3435df806c61b24b13328db128c58868f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1017,9 +1017,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone-haiku"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde6edd6cef363e9359ed3c98ba64590ba9eecba2293eb5a723ab32aee8926aa"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -1591,9 +1591,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,7 @@ reqwest = { version = "0.11.12", features = ["json"] }
 #* cors
 tower-http = { version = "0.3.4", features = ["cors"]}
 #* graphql
-
-async-graphql = {version = "4.0.15", features = ["chrono", "apollo_tracing"]}
+async-graphql = {version = "4.0.15", features = ["chrono", "dataloader"]}
 async-graphql-axum = "4.0.13"
 #*postgres
 sqlx = { version = "0.6.1", features = ["postgres", "runtime-tokio-rustls", "time", "chrono"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ thiserror = "1.0.37"
 #* log
 tracing = "0.1.37"
 tracing-subscriber = {version = "0.3.16", features = ["json", "default"]}
-#* cookie ** lintで落ちるのでとりあえずコメント **
+#* cookie
 cookie = "0.16.1"
 #* global variable
 once_cell = "1.15.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,3 +57,5 @@ jsonwebtoken = "8.1.1"
 lettre = { version = "0.10", features = ["tokio1", "tokio1-rustls-tls", "tokio1-native-tls"]}
 #* faker
 fake = { version = "2.5"}
+#* async trait
+async-trait = "0.1.57"

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -12,6 +12,7 @@ use self::resolvers::{
 };
 
 pub mod auth;
+pub mod loader;
 pub mod mail;
 pub mod models;
 pub mod mutations;

--- a/src/graphql/loader.rs
+++ b/src/graphql/loader.rs
@@ -1,0 +1,35 @@
+use std::sync::Arc;
+
+use async_graphql::dataloader::DataLoader;
+use sqlx::{Pool, Postgres};
+
+use self::{prefecture::PrefectureLoader, sport::SportLoader, tag::TagLoader, user::UserLoader};
+
+pub mod prefecture;
+pub mod sport;
+pub mod tag;
+pub mod user;
+
+pub struct Loaders {
+    pub user_loader: DataLoader<UserLoader>,
+    pub tag_loader: DataLoader<TagLoader>,
+    pub prefecture_loader: DataLoader<PrefectureLoader>,
+    pub sport_loader: DataLoader<SportLoader>,
+}
+
+impl Loaders {
+    pub fn new(pool: &Arc<Pool<Postgres>>) -> Self {
+        let user_loader = DataLoader::new(UserLoader { pool: pool.clone() }, tokio::spawn);
+        let tag_loader = DataLoader::new(TagLoader { pool: pool.clone() }, tokio::spawn);
+        let prefecture_loader =
+            DataLoader::new(PrefectureLoader { pool: pool.clone() }, tokio::spawn);
+        let sport_loader = DataLoader::new(SportLoader { pool: pool.clone() }, tokio::spawn);
+
+        Self {
+            user_loader,
+            tag_loader,
+            prefecture_loader,
+            sport_loader,
+        }
+    }
+}

--- a/src/graphql/loader/prefecture.rs
+++ b/src/graphql/loader/prefecture.rs
@@ -1,0 +1,36 @@
+use std::{collections::HashMap, sync::Arc};
+
+use async_graphql::dataloader::Loader;
+use async_trait::async_trait;
+use sqlx::{PgPool, Postgres, QueryBuilder};
+
+use crate::graphql::models::prefecture::Prefecture;
+
+pub struct PrefectureLoader {
+    pub pool: Arc<PgPool>,
+}
+
+#[async_trait]
+impl Loader<i64> for PrefectureLoader {
+    type Value = Prefecture;
+    type Error = Arc<sqlx::Error>;
+
+    async fn load(&self, keys: &[i64]) -> Result<HashMap<i64, Self::Value>, Self::Error> {
+        let sql = "SELECT * FROM prefectures WHERE id IN (";
+        let mut query_builder = QueryBuilder::<Postgres>::new(sql);
+        let mut separated = query_builder.separated(", ");
+        for key in keys.iter() {
+            separated.push_bind(key);
+        }
+        separated.push_unseparated(") ");
+        let query = query_builder.build_query_as::<Prefecture>();
+        let prefectures = query.fetch_all(&*self.pool).await?;
+
+        // { prefecture_id: Prefecture }の形になるように整形
+        let prefectures_hash: HashMap<i64, Prefecture> = prefectures
+            .iter()
+            .map(|prefecture| (prefecture.id, prefecture.to_owned()))
+            .collect();
+        Ok(prefectures_hash)
+    }
+}

--- a/src/graphql/loader/sport.rs
+++ b/src/graphql/loader/sport.rs
@@ -1,0 +1,36 @@
+use std::{collections::HashMap, sync::Arc};
+
+use async_graphql::dataloader::Loader;
+use async_trait::async_trait;
+use sqlx::{PgPool, Postgres, QueryBuilder};
+
+use crate::graphql::models::sport::Sport;
+
+pub struct SportLoader {
+    pub pool: Arc<PgPool>,
+}
+
+#[async_trait]
+impl Loader<i64> for SportLoader {
+    type Value = Sport;
+    type Error = Arc<sqlx::Error>;
+
+    async fn load(&self, keys: &[i64]) -> Result<HashMap<i64, Self::Value>, Self::Error> {
+        let sql = "SELECT * FROM sports WHERE id IN (";
+        let mut query_builder: QueryBuilder<Postgres> = QueryBuilder::new(sql);
+        let mut separated = query_builder.separated(", ");
+        for key in keys.iter() {
+            separated.push(key);
+        }
+        separated.push_unseparated(")");
+        let query = query_builder.build_query_as::<Sport>();
+        let sports = query.fetch_all(&*self.pool).await?;
+
+        // { sport_id: Sport }の形になるように整形
+        let sports_hash: HashMap<i64, Sport> = sports
+            .iter()
+            .map(|sport| (sport.id, sport.to_owned()))
+            .collect();
+        Ok(sports_hash)
+    }
+}

--- a/src/graphql/loader/tag.rs
+++ b/src/graphql/loader/tag.rs
@@ -1,0 +1,58 @@
+use std::{collections::HashMap, sync::Arc};
+
+use async_graphql::{dataloader::Loader, futures_util::TryStreamExt};
+use async_trait::async_trait;
+use sqlx::{PgPool, Postgres, QueryBuilder, Row};
+
+use crate::graphql::models::tag::Tag;
+
+pub struct TagLoader {
+    pub pool: Arc<PgPool>,
+}
+
+#[async_trait]
+impl Loader<i64> for TagLoader {
+    type Value = Vec<Tag>;
+    type Error = Arc<sqlx::Error>;
+
+    // 募集に紐づいているタグを取得する 募集のIDからタグを複数
+    async fn load(&self, keys: &[i64]) -> Result<HashMap<i64, Self::Value>, Self::Error> {
+        let sql = r#"
+            SELECT t.id, t.name, r_t.recruitment_id
+            FROM tags as t
+            INNER JOIN recruitment_tags as r_t
+            ON t.id = r_t.tag_id
+            WHERE r_t.recruitment_id IN (
+        "#;
+
+        let mut query_builder = QueryBuilder::<Postgres>::new(sql);
+        let mut separated = query_builder.separated(", ");
+        for key in keys.iter() {
+            separated.push_bind(key);
+        }
+        separated.push_unseparated(") ");
+
+        let query = query_builder.build();
+        let mut rows = query.fetch(&*self.pool);
+
+        // { recruitment_id: [tag] }の形になるように整形
+        let mut recruitment_tags_hash: HashMap<i64, Vec<Tag>> = HashMap::new();
+        while let Some(row) = rows.try_next().await? {
+            let id: i64 = row.get("id");
+            let name: &str = row.get("name");
+            let tag = Tag {
+                id,
+                name: name.to_string(),
+            };
+            let recruitment_id: i64 = row.get("recruitment_id");
+            if let Some(current_tags) = recruitment_tags_hash.get(&recruitment_id) {
+                let mut new_tags = current_tags.to_owned();
+                new_tags.push(tag);
+                recruitment_tags_hash.insert(recruitment_id, new_tags)
+            } else {
+                recruitment_tags_hash.insert(recruitment_id, vec![tag])
+            };
+        }
+        Ok(recruitment_tags_hash)
+    }
+}

--- a/src/graphql/loader/user.rs
+++ b/src/graphql/loader/user.rs
@@ -1,0 +1,35 @@
+use async_graphql::dataloader::*;
+use async_graphql::*;
+use async_trait::async_trait;
+use sqlx::{PgPool, Postgres, QueryBuilder};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::graphql::models::user::User;
+
+pub struct UserLoader {
+    pub pool: Arc<PgPool>,
+}
+
+#[async_trait]
+impl Loader<i64> for UserLoader {
+    type Value = User;
+    type Error = Arc<sqlx::Error>;
+
+    async fn load(&self, keys: &[i64]) -> Result<HashMap<i64, Self::Value>, Self::Error> {
+        let sql = "SELECT * FROM users WHERE id IN (";
+        let mut query_builder = QueryBuilder::<Postgres>::new(sql);
+        let mut separated = query_builder.separated(", ");
+        for key in keys.iter() {
+            separated.push_bind(*key as i64);
+        }
+        separated.push_unseparated(") ");
+        let query = query_builder.build_query_as::<User>();
+
+        let users = query.fetch_all(&*self.pool).await?;
+
+        // { user_id: User }の形に整形する
+        let users_hash: HashMap<i64, User> = users.iter().map(|u| (u.id, u.to_owned())).collect();
+        Ok(users_hash)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use std::{sync::Arc, *};
 use tower_http::cors::CorsLayer;
 use tracing_subscriber::fmt::format::FmtSpan;
 
+use self::graphql::loader::Loaders;
 use self::graphql::{GraphqlSchema, Mutation, Query};
 use crate::graphql::auth::{cookie::get_value_from_cookie, jwt::get_user_from_token};
 pub mod config;
@@ -49,8 +50,10 @@ async fn main() {
         let config = get_config();
         let pool = pool(config).await.unwrap();
         let arc_pool = Arc::new(pool);
+        let loaders = Loaders::new(&arc_pool);
         let schema = Schema::build(Query::default(), Mutation::default(), EmptySubscription)
             .data(arc_pool.clone())
+            .data(loaders)
             .data(config)
             .finish();
 


### PR DESCRIPTION
## やったこと
N+1への対応でdataloaderを実装 
async-graphqlのexampleを参考に実装
自分が作成した募集を取得できるように
テストデータで募集にタグを紐づけるように

## やらないこと
とりあえずprefecture,sport,tags,userのloaderを実装
他はやっていない

## できるようになること（ユーザ目線）
自分が作成した募集を取得できるようになる

## できなくなること（ユーザ目線）
特になし

## 動作確認
ログでN+1が発生していたが、loader実装後にN+1が起きていないことを確認
テストデータにタグが紐づいていることを確認

## その他
特になし
