### PR TITLE
Feature/recruitment_stocks

### DIFF
--- a/db/migrations/000008_create_table_stocks.down.sql
+++ b/db/migrations/000008_create_table_stocks.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS "stocks";

--- a/db/migrations/000008_create_table_stocks.up.sql
+++ b/db/migrations/000008_create_table_stocks.up.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS "stocks"(
+  "id" BIGSERIAL PRIMARY KEY,
+  "user_id" BIGINT NOT NULL,
+  "recruitment_id" BIGINT NOT NULL,
+  "created_at" TIMESTAMP WITH TIME ZONE NOT NULL,
+  "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL,
+  FOREIGN KEY("user_id") 
+    REFERENCES "users"("id")
+    ON DELETE CASCADE,
+  FOREIGN KEY("recruitment_id") 
+    REFERENCES "recruitments"("id")
+    ON DELETE CASCADE,
+  UNIQUE("user_id", "recruitment_id")
+);
+CREATE INDEX ON "stocks"("user_id");
+CREATE INDEX ON "stocks"("recruitment_id");

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use async_graphql::{EmptySubscription, MergedObject, Schema, ID};
-use base64::{decode_config, URL_SAFE};
+use base64::{decode_config, encode_config, URL_SAFE};
 
 use self::resolvers::{
     prefecture_resolver::PrefectureQuery,
@@ -32,6 +32,10 @@ pub struct Query(
 pub struct Mutation(UserMutation, RecruitmentMutation, TagMutation);
 
 pub type GraphqlSchema = Schema<Query, Mutation, EmptySubscription>;
+
+pub fn id_encode(name: &str, id: i64) -> String {
+    encode_config(format!("{}:{}", name, id), base64::URL_SAFE)
+}
 
 pub fn id_decode(id: &ID) -> Result<i64> {
     let bytes = decode_config(id.as_bytes(), URL_SAFE)?;

--- a/src/graphql/models/user.rs
+++ b/src/graphql/models/user.rs
@@ -125,7 +125,7 @@ impl User {
 
 #[derive(Clone, Debug)]
 pub struct Viewer {
-    pub account_user: Option<User>,
+    pub account_user: User,
 }
 
 #[Object]

--- a/src/graphql/models/user.rs
+++ b/src/graphql/models/user.rs
@@ -130,7 +130,7 @@ pub struct Viewer {
 
 #[Object]
 impl Viewer {
-    async fn account_user(&self) -> Option<User> {
+    async fn account_user(&self) -> User {
         self.account_user.clone()
     }
 }

--- a/src/graphql/resolvers/user_resolver.rs
+++ b/src/graphql/resolvers/user_resolver.rs
@@ -63,9 +63,7 @@ impl UserMutation {
         match jwt::token_encode(claims) {
             Ok(token) => {
                 jwt::set_jwt_cookie(token, ctx);
-                let viewer = Viewer {
-                    account_user: user.into(),
-                };
+                let viewer = Viewer { account_user: user };
                 Ok(RegisterUserSuccess { viewer }.into())
             }
             Err(e) => Err(e.into()),
@@ -110,9 +108,7 @@ impl UserMutation {
                 match jwt::token_encode(claims) {
                     Ok(token) => {
                         jwt::set_jwt_cookie(token, ctx);
-                        let viewer = Viewer {
-                            account_user: user.into(),
-                        };
+                        let viewer = Viewer { account_user: user };
                         tracing::info!("User authenticated.");
                         Ok(LoginUserSuccess { viewer }.into())
                     }

--- a/src/graphql/resolvers/user_resolver.rs
+++ b/src/graphql/resolvers/user_resolver.rs
@@ -20,12 +20,17 @@ pub struct UserQuery;
 
 #[Object]
 impl UserQuery {
-    async fn viewer(&self, ctx: &Context<'_>) -> Result<Viewer> {
+    async fn viewer(&self, ctx: &Context<'_>) -> Result<Option<Viewer>> {
         let user = get_viewer(ctx).await;
-        let viewer = Viewer {
-            account_user: { user.to_owned() },
-        };
-        Ok(viewer)
+        match user {
+            Some(user) => {
+                let viewer = Viewer {
+                    account_user: { user.to_owned() },
+                };
+                Ok(Some(viewer))
+            }
+            None => Ok(None),
+        }
     }
 }
 


### PR DESCRIPTION
## やったこと
stocksテーブルを作成するためにマイグレーションファイルを作成
クライアント側で使用するユニークなIDを生成する処理を追加
ユーザーの募集一覧を取得できるように処理を追加
type Userにrecruitmentsフィールドを追加してユーザーの募集を取得できるように
query viewerは必須になっていたがnull許容に変更
viewerに自分が作成した募集を取得できるようにrecruitmentsフィールドを追加
account_userはnot-nullに変更したためinto()を削除

## やらないこと
type Userの募集はまだ取得できないので確認しない

## できるようになること（ユーザ目線）
特になし

## できなくなること（ユーザ目線）
特になし

## 動作確認
追加した各フィールドから募集一覧を取得できることを確認(viewerのrecruitmentsだけ実行している)

## その他
とりあえずViewerとUserで募集フィールドをそれぞれ持っているがクエリは公開済みかそうでないかでしかないため同じ処理にしてしまってもいいのかもしれない
